### PR TITLE
change redis7 config to run with scripts

### DIFF
--- a/redis7/etc/redis/redis.conf
+++ b/redis7/etc/redis/redis.conf
@@ -72,8 +72,7 @@
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
 # JUST COMMENT OUT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#bind 127.0.0.1 -::1
-bind 172.32.255.2
+bind 172.44.0.2
 
 # Protected mode is a layer of security protection, in order to avoid that
 # Redis instances left open on the internet are accessed and exploited.
@@ -452,7 +451,7 @@ rdb-del-sync-files no
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir /redis-data
+dir /
 
 ################################# REPLICATION #################################
 


### PR DESCRIPTION
Previously, the config required a directory which did not exist and an IP address different from the one provided by the script.